### PR TITLE
Implement delete routers and view cve for routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Setting up](#setting-up)
 - [Using this repository](#using-this-repository)
+- [Running this application](#running-this-application)
 
 ## Setting up
 
@@ -39,6 +40,24 @@ Include "/Applications/mappstack-7.1.23-0/apps/adap/conf/httpd-prefix.conf"
 
 5. Save the file.
 
+##### Get `psycopg2` for python initialiser
+
+For Mac users, you can follow these steps:
+1. `brew install postgresql`
+2. `gem install pg`
+3. `pip install psycopg2`
+
+For Windows users, you can follow these steps:
+1. `python -m pip install -U pip`
+2. `python -m pip install psycopg2`
+
+##### Get `json` files for CVE database
+
+1. Go to https://nvd.nist.gov/vuln/data-feeds#JSON_FEED
+2. Download the `.zip` files for `CVE-Modified`, `CVE-Recent`, `CVE-2018`...`CVE-2012` (inclusive).
+3. Unzip the files.
+4. Shift the extracted `json` files into a folder named `json` in the `init` folder (i.e. on the same level as the `sql` folder).
+
 ## Using this repository
 
 The steps in this section can be executed whenever there are updates to this repository.
@@ -48,9 +67,8 @@ When there are changes to the `attack.sh` file:
 2. Navigate to the project folder.
 3. Run by doing `./attack.sh`.
 
-When there are changes to the `SQL` folder:
-1. Get the latest changes locally using `git pull`. Alternatively, you can just copy and paste the commands directly from GitHub.
-2. Copy and paste the commands into pgAdmin4 before using the application.
+When there are changes to the `init` folder:
+1. Get the latest changes locally using `git pull`.
 
 When there are changes to the `adap` folder:
 1. Get the latest changes locally using `git pull`.
@@ -60,3 +78,15 @@ When there are changes to the `adap` folder:
 5. Go to `localhost:8080/adap` to view the site.
 
 Before inter-page routing is completed, individual pages can be accessed by heading to `localhost:8080/adap/<filename>`.
+
+## Running this application
+
+To run this application:
+1. `cd` into the `init` folder, and run the Python script to initalise the database:
+
+`python initialise_db.py`
+
+The script will run for approximately 2.5 minutes. This is because it is loading ~5 years worth of CVE data into the database.
+
+2. Restart the servers using `manager-osx` (for example).
+3. Go to `localhost:8080/adap` to view the site.

--- a/SQL/dummy.sql
+++ b/SQL/dummy.sql
@@ -1,2 +1,0 @@
-/* Dummy SQL file */
-CREATE TABLE USERS();

--- a/SQL/test_values.sql
+++ b/SQL/test_values.sql
@@ -1,0 +1,5 @@
+INSERT into company_account
+VALUES('test_company', 'cs3235@gmail.com', '123', '12345678', 'NUS', '123456');
+
+INSERT into cve
+VALUES('LINKSYS EA7500', '3', 'CVE ID: 2018-19-20\nDetails: Allows attackers to take over the router remotely.');

--- a/SQL/test_values.sql
+++ b/SQL/test_values.sql
@@ -1,5 +1,0 @@
-INSERT into company_account
-VALUES('test_company', 'cs3235@gmail.com', '123', '12345678', 'NUS', '123456');
-
-INSERT into cve
-VALUES('LINKSYS EA7500', '3', 'CVE ID: 2018-19-20\nDetails: Allows attackers to take over the router remotely.');

--- a/adap/htdocs/css/view_routers.css
+++ b/adap/htdocs/css/view_routers.css
@@ -1,0 +1,6 @@
+/* scrolling mechanism for cve content */
+.cve {
+  height: 65%;
+  word-wrap: break-word;
+  overflow-y: scroll;
+}

--- a/adap/htdocs/js/add_router.js
+++ b/adap/htdocs/js/add_router.js
@@ -21,7 +21,7 @@ $("#add_router").submit(function(event) {
   const version = target.version.value;
 
   serializedData = 'mac_address=' + mac_address 
-      + '&model=' + model
+      + '&model=' + model.toUpperCase()
       + '&version=' + version
       + '&company_email=' + company_email;
   console.log("data: " + serializedData);

--- a/adap/htdocs/js/add_router.js
+++ b/adap/htdocs/js/add_router.js
@@ -21,7 +21,7 @@ $("#add_router").submit(function(event) {
   const version = target.version.value;
 
   serializedData = 'mac_address=' + mac_address 
-      + '&model=' + model.toUpperCase()
+      + '&model=' + model.toLowerCase()
       + '&version=' + version
       + '&company_email=' + company_email;
   console.log("data: " + serializedData);

--- a/adap/htdocs/js/delete_router.js
+++ b/adap/htdocs/js/delete_router.js
@@ -1,0 +1,17 @@
+// Prepare to redirect to the view routers page
+$(document).ready(triggerTimeout);
+
+function triggerTimeout() {
+  window.setTimeout(redirectToViewPage, 2000);
+
+  serializedData = 'mac_address=' + mac_address;
+  // Fire off the request to php/delete_router.php
+  request = $.post (
+    "../php/delete_router.php",
+    serializedData
+  );
+}
+
+function redirectToViewPage() {
+  $(location).attr('href', "view_routers.php");
+}

--- a/adap/htdocs/js/edit_router.js
+++ b/adap/htdocs/js/edit_router.js
@@ -23,7 +23,7 @@ $("#edit_router").submit(function(event) {
   mac_addr = mac_address;
 
   serializedData = 'mac_address=' + mac_address 
-      + '&model=' + model.toUpperCase()
+      + '&model=' + model.toLowerCase()
       + '&version=' + version
       + '&original_mac_addr=' + original_mac_addr;
   console.log("data: " + serializedData);

--- a/adap/htdocs/js/edit_router.js
+++ b/adap/htdocs/js/edit_router.js
@@ -23,7 +23,7 @@ $("#edit_router").submit(function(event) {
   mac_addr = mac_address;
 
   serializedData = 'mac_address=' + mac_address 
-      + '&model=' + model
+      + '&model=' + model.toUpperCase()
       + '&version=' + version
       + '&original_mac_addr=' + original_mac_addr;
   console.log("data: " + serializedData);

--- a/adap/htdocs/js/view_cve.js
+++ b/adap/htdocs/js/view_cve.js
@@ -24,31 +24,36 @@ function searchCveDatabase(routerInfo) {
   request = $.post(
     "../php/view_cve.php",
     serializedRouterInfo,
-    checkIfFound
+    parseDatabaseResponse
   );
 }
 
-// Check if the query is successfully found in the database
-function checkIfFound(response) {
-  console.log(response);
+// Parse the response from the database
+function parseDatabaseResponse(response) {
   response = JSON.parse(response);
+  console.log(response);
   var numOfResponses = response.numOfResults;
-  var result = response.result;
+  var results = response.results;
 
   if (numOfResponses != 0) {
-    showCveDetails(result);
+    var fullResult = ""
+
+    console.log(results);
+    
+    for (i = 0; i < numOfResponses; i++) {
+      var currResult = results[i];
+
+      fullResult += "==================\n"
+
+      fullResult += "CVE ID: " + currResult.cve_id + "\n\n";
+      fullResult += "Severity: " + currResult.cve_severity + "\n\n";
+      fullResult += "Description: " + currResult.cve_description + "\n\n";
+    }
+    showCveDetails(fullResult);
   } else {
-    var result = "There is no known CVE associated with this router model and firmware version!";
-    showCveDetails(result);
+    var STANDARD_REPLY = "There is no known CVE associated with this router model and firmware version!";
+    showCveDetails(STANDARD_REPLY);
   }
-}
-
-// Default CVE database (online) to search
-const onlineDatabase = "https://www.cvedetails.com/google-search-results.php?";
-
-// Get cve search results from an online database using jQuery
-function getCveFromOnlineDatabse() {
-
 }
 
 // Display a given response in the card reveal

--- a/adap/htdocs/js/view_cve.js
+++ b/adap/htdocs/js/view_cve.js
@@ -4,14 +4,23 @@ $('img').click(function(event) {
   searchCveDatabase(target.id);
 });
 
+// Helps to identify the specific card to modify
 var counter;
 
-// Try searching for result in the current database first
+// Stores the router information for further queries
+var serializedRouterInfo;
+
+// Search for result in the current database first
 function searchCveDatabase(routerInfo) {
   var parsedRouterInfo = routerInfo.split(" ");
   counter = parsedRouterInfo[0];
-  var serializedRouterInfo = parsedRouterInfo[1];
+  serializedRouterInfo = parsedRouterInfo[1];
 
+  for (i = 2; i < parsedRouterInfo.length; i++) {
+    serializedRouterInfo += "+" + parsedRouterInfo[i];
+  }
+
+  console.log("serialized router info: " + serializedRouterInfo);
   request = $.post(
     "../php/view_cve.php",
     serializedRouterInfo,
@@ -22,24 +31,28 @@ function searchCveDatabase(routerInfo) {
 // Check if the query is successfully found in the database
 function checkIfFound(response) {
   console.log(response);
-  var numOfResponses = response[0];
-  var responses = response[1];
+  response = JSON.parse(response);
+  var numOfResponses = response.numOfResults;
+  var result = response.result;
 
   if (numOfResponses != 0) {
-    showCveDetails(responses);
+    showCveDetails(result);
   } else {
     var result = "There is no known CVE associated with this router model and firmware version!";
     showCveDetails(result);
   }
 }
 
-// Displays a given response in the card reveal
-function showCveDetails(responses) {
-  console.log("current counter: " + counter);
-  $("#cve_content" + counter).text("Lorem ipsum dolor sit amet, consectetur adipiscing elit," 
-   + "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam," 
-   + "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
-   + "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat "
-   + "nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia "
-   + "deserunt mollit anim id est laborum.");
+// Default CVE database (online) to search
+const onlineDatabase = "https://www.cvedetails.com/google-search-results.php?";
+
+// Get cve search results from an online database using jQuery
+function getCveFromOnlineDatabse() {
+
+}
+
+// Display a given response in the card reveal
+function showCveDetails(result) {
+  var obj = $("#cve_content" + counter).text(result);
+  obj.html(obj.html().replace(/\\n/g,'<br><br>'));
 }

--- a/adap/htdocs/js/view_cve.js
+++ b/adap/htdocs/js/view_cve.js
@@ -1,0 +1,45 @@
+// Trigger cve view only when image is clicked
+$('img').click(function(event) {
+  var target = event.target;
+  searchCveDatabase(target.id);
+});
+
+var counter;
+
+// Try searching for result in the current database first
+function searchCveDatabase(routerInfo) {
+  var parsedRouterInfo = routerInfo.split(" ");
+  counter = parsedRouterInfo[0];
+  var serializedRouterInfo = parsedRouterInfo[1];
+
+  request = $.post(
+    "../php/view_cve.php",
+    serializedRouterInfo,
+    checkIfFound
+  );
+}
+
+// Check if the query is successfully found in the database
+function checkIfFound(response) {
+  console.log(response);
+  var numOfResponses = response[0];
+  var responses = response[1];
+
+  if (numOfResponses != 0) {
+    showCveDetails(responses);
+  } else {
+    var result = "There is no known CVE associated with this router model and firmware version!";
+    showCveDetails(result);
+  }
+}
+
+// Displays a given response in the card reveal
+function showCveDetails(responses) {
+  console.log("current counter: " + counter);
+  $("#cve_content" + counter).text("Lorem ipsum dolor sit amet, consectetur adipiscing elit," 
+   + "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam," 
+   + "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+   + "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat "
+   + "nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia "
+   + "deserunt mollit anim id est laborum.");
+}

--- a/adap/htdocs/php/delete_router.php
+++ b/adap/htdocs/php/delete_router.php
@@ -1,0 +1,9 @@
+<?php
+  // Connect to the database
+  include("../config.php");
+
+  // Delete router function
+  $query = "DELETE FROM router WHERE mac_address = '$_POST[mac_address]'";
+  $result = pg_query($db, $query)
+              or die('Delete failed.');
+?>

--- a/adap/htdocs/php/view_cve.php
+++ b/adap/htdocs/php/view_cve.php
@@ -3,15 +3,18 @@
   include("../config.php");
 
   // Query for CVEs for the given router model and version
-  $query = "SELECT vulnerability FROM cve
-            WHERE router_model = '$_POST[router_model]'
-            AND router_version = '$_POST[router_version]'";
+  $query = "SELECT cve_id, cve_severity, cve_description FROM cve
+            WHERE router_model = '$_POST[router_model]'";
 
   $result = pg_query($db, $query)
               or die('Query failed.');
 
   $num = pg_num_rows($result);
+  $response = array("numOfResults"=>$num);
 
-  $response = array("numOfResults"=>$num, "result"=>pg_fetch_row($result));
+  while($row = pg_fetch_assoc($result)) {
+    $response["results"][] = $row;
+  }
+
   echo json_encode($response);
 ?>

--- a/adap/htdocs/php/view_cve.php
+++ b/adap/htdocs/php/view_cve.php
@@ -11,17 +11,7 @@
               or die('Query failed.');
 
   $num = pg_num_rows($result);
-  echo $num;
-    
-  // while ($row = pg_fetch_row($result)) {
-  //   echo $row[0];
-  //   echo "\n";
-  // }
 
-  // If it is found, send the vunlnerability back to be displayed
-  // if ($numResults != 0) {
-  //   while ($row = pg_fetch_row($result)) {
-  //     echo $row[0];
-  //   }
-  // }
+  $response = array("numOfResults"=>$num, "result"=>pg_fetch_row($result));
+  echo json_encode($response);
 ?>

--- a/adap/htdocs/php/view_cve.php
+++ b/adap/htdocs/php/view_cve.php
@@ -1,0 +1,27 @@
+<?php
+  // Connect to the database
+  include("../config.php");
+
+  // Query for CVEs for the given router model and version
+  $query = "SELECT vulnerability FROM cve
+            WHERE router_model = '$_POST[router_model]'
+            AND router_version = '$_POST[router_version]'";
+
+  $result = pg_query($db, $query)
+              or die('Query failed.');
+
+  $num = pg_num_rows($result);
+  echo $num;
+    
+  // while ($row = pg_fetch_row($result)) {
+  //   echo $row[0];
+  //   echo "\n";
+  // }
+
+  // If it is found, send the vunlnerability back to be displayed
+  // if ($numResults != 0) {
+  //   while ($row = pg_fetch_row($result)) {
+  //     echo $row[0];
+  //   }
+  // }
+?>

--- a/adap/htdocs/router_management/delete_router.php
+++ b/adap/htdocs/router_management/delete_router.php
@@ -1,0 +1,49 @@
+<?php
+  // session_start();
+  // if(!isset($_SESSION[email]) || empty($_SESSION[email]))
+  //   include('headerN.php');
+  // else include ('headerHi.php');
+  include '../homepage/navbar_after_login.php';
+?>
+<!DOCTYPE html>
+<head>
+  <title>ADAP</title>
+  <!--Import Google Icon Font-->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <!--Import materialize.css-->
+  <link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
+  <link rel="stylesheet" type="text/css" href="../css/add_router.css">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <style>
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="row center-align" style="margin-top:20%;">
+      <div class="preloader-wrapper big active">
+      <div class="spinner-layer spinner-blue-only">
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+          </div><div class="gap-patch">
+          <div class="circle"></div>
+          </div><div class="circle-clipper right">
+          <div class="circle"></div>
+          </div>
+          </div>
+        </div>
+        <div class="center-align">
+            <p>Deleting your router information...</p>
+        </div>
+        </div>
+    </div>
+  </div>
+
+  <!-- Import relevant JavaScript files -->
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+  <script type="text/javascript" src="../js/materialize.min.js"></script>
+  <script type="text/javascript">
+    var mac_address = '<?php echo "$_GET[mac_address]";?>';
+  </script>
+  <script type="text/javascript" src="../js/delete_router.js"></script>
+</body>
+</html>

--- a/adap/htdocs/router_management/updated_router.php
+++ b/adap/htdocs/router_management/updated_router.php
@@ -12,6 +12,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <!--Import materialize.css-->
   <link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
+  <link rel="stylesheet" type="text/css" href="../css/view_routers.css">
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style>
@@ -51,7 +52,7 @@
               <div class="card hoverable">
                 <div class="card-content">
                   <div class="row">
-                    <img src="../img/linksys-EA7300.jpg" height="200">
+                    <img class="activator" id="<?php echo $counter ?> router_model=<?php echo $model ?>&router_version=<?php echo $version ?>" src="../img/linksys-EA7300.jpg" height="200">
                   </div>
                   <div class="row">
                       <p>
@@ -68,6 +69,12 @@
                       </p>
                   </div>
                 </div>
+                <div class="card-reveal">
+                  <span class="card-title red-text text-darken-4">CVE Information<i class="material-icons right">close</i></span>
+                  <p><b>Model:</b> <?php echo $model ?></p>
+                  <p><b>Version:</b> <?php echo $version ?></p>
+                  <span style="white-space:pre-wrap;" class="col s12 cve" id="cve_content<?php echo $counter ?>"></span>
+                </div>
               </div>
             </div>
           <?php
@@ -75,5 +82,10 @@
         ?>
     </div>
   </div>
+  
+  <!-- Import jQuery and other relevant JavaScript files -->
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+  <script type="text/javascript" src="../js/materialize.min.js"></script>
+  <script type="text/javascript" src="../js/view_cve.js"></script>
 </body>
 </html>

--- a/adap/htdocs/router_management/view_routers.php
+++ b/adap/htdocs/router_management/view_routers.php
@@ -94,7 +94,7 @@
                   <span class="card-title red-text text-darken-4">CVE Information<i class="material-icons right">close</i></span>
                   <p><b>Model:</b> <?php echo $model ?></p>
                   <p><b>Version:</b> <?php echo $version ?></p>
-                  <span class="col s12 cve" id="cve_content<?php echo $counter ?>"></span>
+                  <span style="white-space:pre-wrap;" class="col s12 cve" id="cve_content<?php echo $counter ?>"></span>
                 </div>
               </div>
             </div>
@@ -106,10 +106,7 @@
 
   <!-- Import jQuery and other relevant JavaScript files -->
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-    <script type="text/javascript" src="../js/materialize.min.js"></script>
-    <script type="text/javascript">
-      var company_email = 'cs3235@gmail.com';
-    </script>
+  <script type="text/javascript" src="../js/materialize.min.js"></script>
   <script type="text/javascript" src="../js/view_cve.js"></script>
 </body>
 </html>

--- a/adap/htdocs/router_management/view_routers.php
+++ b/adap/htdocs/router_management/view_routers.php
@@ -12,6 +12,7 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <!--Import materialize.css-->
   <link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
+  <link rel="stylesheet" type="text/css" href="../css/view_routers.css">
 
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style>
@@ -54,11 +55,13 @@
             echo "<h5 class=\"center\">No router has been whitelisted.</h5>";
           }
 
+          $counter = 0;
           // Create a while loop and loop through result set
           while($row = pg_fetch_assoc($result)){
             $mac_address = $row['mac_address'];
             $model = $row['model'];
             $version = $row['version'];
+            $counter = $counter + 1;
 
             // TODO: display routers
             ?>
@@ -66,7 +69,7 @@
               <div class="card hoverable">
                 <div class="card-content">
                   <div class="row">
-                    <img src="../img/linksys-EA7300.jpg" height="200">
+                    <img class="activator" id="<?php echo $counter ?> router_model=<?php echo $model ?>&router_version=<?php echo $version ?>" src="../img/linksys-EA7300.jpg" height="200">
                   </div>
                   <div class="row">
                       <p>
@@ -84,8 +87,14 @@
                   </div>
                   <div class="row">
                     <a class="waves-effect waves-light orange btn left" href="edit_router.php?mac_address=<?php echo $mac_address?>&model=<?php echo $model ?>&version=<?php echo $version ?>">Edit</a>
-                    <a class="waves-effect waves-light grey btn right" href="delete_router.php?mac_address=<?php echo $mac_address?>&model=<?php echo $model ?>&version=<?php echo $version ?>">Delete</a>
+                    <a class="waves-effect waves-light grey btn right" href="delete_router.php?mac_address=<?php echo $mac_address?>">Delete</a>
                   </div>
+                </div>
+                <div class="card-reveal">
+                  <span class="card-title red-text text-darken-4">CVE Information<i class="material-icons right">close</i></span>
+                  <p><b>Model:</b> <?php echo $model ?></p>
+                  <p><b>Version:</b> <?php echo $version ?></p>
+                  <span class="col s12 cve" id="cve_content<?php echo $counter ?>"></span>
                 </div>
               </div>
             </div>
@@ -94,5 +103,13 @@
         ?>
     </div>
   </div>
+
+  <!-- Import jQuery and other relevant JavaScript files -->
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="../js/materialize.min.js"></script>
+    <script type="text/javascript">
+      var company_email = 'cs3235@gmail.com';
+    </script>
+  <script type="text/javascript" src="../js/view_cve.js"></script>
 </body>
 </html>

--- a/init/initialise_db.py
+++ b/init/initialise_db.py
@@ -1,0 +1,166 @@
+import collections
+import json
+import os
+from pprint import pprint
+import psycopg2
+import re
+
+# Get the details for a particular CVE and store it in a tuple
+def getCveInfo(cveItem):
+  Cve = collections.namedtuple('Cve', ['vendor_data', 'vendor', 'products', 'id', 'severity', 'description'])
+  
+  cve = cveItem["cve"]
+  cveId = cve["CVE_data_meta"]["ID"]
+
+  vendor_data = cve["affects"]["vendor"]["vendor_data"]
+  vendor = ""
+  products = ""
+  if vendor_data:
+    vendor_data = vendor_data[0]
+    vendor = vendor_data["vendor_name"]
+    products = vendor_data["product"]["product_data"]
+
+  cveSeverity = cveItem["impact"]
+  if 'baseMetricV2' in cveSeverity:
+    cveSeverity = cveSeverity["baseMetricV2"]["severity"]
+  if 'baseMetricV3' in cveSeverity:
+    cveSeverity = cveSeverity["baseMetricV3"]["severity"]
+
+  description = cve["description"]
+  if cve["description"]:
+    description = description["description_data"][0]["value"]
+
+  return Cve(vendor_data, vendor, products, cveId, cveSeverity, description)
+
+# Get the details for a particular product and store it in a tuple
+def getProductInfo(cve, productItem):
+  Product = collections.namedtuple('Product', ['model', 'version'])
+
+  product_name = productItem["product_name"]
+  product_model = cve.vendor + " " + product_name
+  product_version = productItem["version"]["version_data"][0]["version_value"]
+
+  return Product(product_model, product_version)
+
+# Check if the current CVE and product conforms to the specifications in the schema
+def doesNotConformToSpecs(cve, product):
+  return len(product.model) > 150 or len(product.version) > 20 or len(cve.id) > 16 or len(cve.severity) > 6 or len(cve.description) > 500
+
+# Print a series of debugging statements given a product and its corresponding cve
+def printDebugStatements(cve, product):
+  print("Product: " + product.model)
+  print("Version: " + product.version)
+  print("Cve id: " + cve.id)
+  print("Severity: " + cve.severity)
+  print("Description: " + cve.description)
+  print("\n")
+
+# Insert product and cve details into the database
+def insert(cursor, product, cve):
+  query = "INSERT INTO cve VALUES (%s, %s, %s, %s, %s)"
+  cursor.execute(query, (product.model, product.version, cve.id, cve.severity, cve.description))
+  print("Product and cve are inserted successfully! :)\n")
+
+# Update cve details for a product existing in the database
+def update(cursor, product, cve):
+  query = "UPDATE cve SET cve_severity = %s, cve_description = %s WHERE router_model = %s AND router_version = %s AND cve_id = %s"
+  cursor.execute(query, (cve.severity, cve.description, product.model, product.version, cve.id))
+  print("Product and cve are updated successfully! :)\n")
+
+# Check if a given pair of product and cve already exists in the database
+def isFoundInDatabase(cursor, product, cve):
+  query = "SELECT FROM cve WHERE router_model = %s AND router_version = %s AND cve_id = %s"
+  cursor.execute(query, (product.model, product.version, cve.id))
+  entry = cursor.fetchone()
+  return type(entry) is not None
+
+def main():
+  # Connect to an existing database
+  conn = psycopg2.connect("host=localhost port=5432 dbname=adap user=postgres password=123")
+
+  # Open a cursor to perform database operations
+  cursor = conn.cursor()
+
+  # Create tables according to the schema
+  cursor.execute(open("sql/schema.sql", "r").read())
+
+  # Create dummy account and data
+  cursor.execute(open("sql/company_account.sql", "r").read())
+  cursor.execute(open("sql/router.sql", "r").read())
+
+  # Parse JSON files from https://nvd.nist.gov/vuln/data-feeds#JSON_FEED
+  directory = "json"
+  for filename in os.listdir(directory):
+
+    # Settle the initial insertions first
+    if filename.endswith(".json") and "modified" not in filename and "recent" not in filename:
+      filename = os.path.join(directory, filename)
+      data = json.load(open(filename))
+
+      cveList = data["CVE_Items"]
+      for cveItem in cveList:
+        try:
+          cve = getCveInfo(cveItem)
+
+          # Skip the insertion if there is no vendor data
+          if not cve.vendor_data:
+            continue
+        
+          for productItem in cve.products:
+            product = getProductInfo(cve, productItem)
+
+            # Unlikely to be router if the details do not conform to our specs
+            if (doesNotConformToSpecs(cve, product)):
+              continue
+
+            printDebugStatements(cve, product)
+            insert(cursor, product, cve)
+
+        except (Exception, psycopg2.DatabaseError) as error:
+          print(error)
+          break
+      
+  # Update entries modified and added recently
+  # Do another 'for' loop to control the order of insertions
+  for filename in os.listdir(directory):
+    if filename.endswith(".json") and ("modified" in filename or "recent" in filename):
+      filename = os.path.join(directory, filename)
+      data = json.load(open(filename))
+
+      cveList = data["CVE_Items"]
+      for cveItem in cveList:
+        try:
+          cve = getCveInfo(cveItem)
+
+          if not cve.vendor_data:
+            continue
+        
+          for productItem in cve.products:
+            product = getProductInfo(cve, productItem)
+
+            # Unlikely to be router if the details do not conform to our specs
+            if (doesNotConformToSpecs(cve, product)):
+              continue
+
+            printDebugStatements(cve, product)
+            
+            # Update the entry if it exists in the database, and insert the entry otherwise
+            if (isFoundInDatabase(cursor, product, cve)):
+              update(cursor, product, cve)
+            else:
+              insert(cursor, product, cve)
+          
+        except (Exception, psycopg2.DatabaseError) as error:
+          print(error)
+          break
+
+  # Make the changes to the database persistent
+  conn.commit()
+
+  # Close communication with the database
+  cursor.close()
+  conn.close()
+
+# Execute the program
+if __name__ == "__main__":
+  main()

--- a/init/sql/company_account.sql
+++ b/init/sql/company_account.sql
@@ -1,0 +1,2 @@
+INSERT into company_account
+VALUES('test_company', 'cs3235@gmail.com', '123', '12345678', 'NUS', '123456');

--- a/init/sql/router.sql
+++ b/init/sql/router.sql
@@ -1,2 +1,2 @@
 INSERT into router
-VALUES('cs3235@gmail.com', '00:11:22:33:44:55', 'LINKSYS EA4500', '3');
+VALUES('cs3235@gmail.com', '00:11:22:33:44:55', 'linksys ea4500', '3');

--- a/init/sql/router.sql
+++ b/init/sql/router.sql
@@ -1,0 +1,2 @@
+INSERT into router
+VALUES('cs3235@gmail.com', '00:11:22:33:44:55', 'LINKSYS EA4500', '3');

--- a/init/sql/schema.sql
+++ b/init/sql/schema.sql
@@ -25,8 +25,10 @@ CREATE TABLE router (
 CREATE TABLE cve (
 	router_model VARCHAR(150),
 	router_version VARCHAR(20),
-	vulnerability VARCHAR(500),
-	PRIMARY KEY (router_model, router_version)
+	cve_id VARCHAR(16),
+	cve_severity VARCHAR(7),
+	cve_description VARCHAR(500),
+	PRIMARY KEY (router_model, router_version, cve_id)
 );
 
 /* SET datestyle = "ISO, YMD"; */


### PR DESCRIPTION
Details and questions for reviewers:

For delete routers:
- Should the self-imposed "loading time" for each delete action be reduced?

For viewing cve:
- Follow the updates in `README.md` in this PR prior to testing the branch
- There are issues with checking the version (because some values are `*` etc. you can't just do an equality check) when retrieving relevant CVE results
- Should the description be shortened, and link to another page where the full description is displayed?
- The current CVE database contains *all* CVEs, not just those limited to routers...is there a better approach?
- The reason why it uses a database is because online sites are protected by cross origin policies

*The python program will create tables, and insert a dummy value into users and routers, followed by the cves from the JSON feed from [NVD](https://nvd.nist.gov/vuln/data-feeds#JSON_FEED)
*Router models are converted to lower case before insertion 
*May update the look of viewing cve again if time permits. But please review first